### PR TITLE
Fix Blender/Dnerf dataset compatibility

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -269,10 +269,16 @@ def readCamerasFromTransforms(path, transformsfile, white_background, extension=
         for idx, frame in enumerate(frames):
             cam_name = os.path.join(path, frame["file_path"] + extension)
             time = mapper[frame["time"]]
-            matrix = np.linalg.inv(np.array(frame["transform_matrix"]))
-            R = -np.transpose(matrix[:3,:3])
-            R[:,0] = -R[:,0]
-            T = -matrix[:3, 3]
+            
+            # NeRF 'transform_matrix' is a camera-to-world transform
+            c2w = np.array(frame["transform_matrix"])
+            # change from OpenGL/Blender camera axes (Y up, Z back) to COLMAP (Y down, Z forward)
+            c2w[:3, 1:3] *= -1
+
+            # get the world-to-camera transform and set R, T
+            w2c = np.linalg.inv(c2w)
+            R = np.transpose(w2c[:3,:3])  # R is stored transposed due to 'glm' in CUDA code
+            T = w2c[:3, 3]
 
             image_path = os.path.join(path, cam_name)
             image_name = Path(cam_name).stem


### PR DESCRIPTION
The transform of `transform_matrix` is different from how it is currently handled in *3DGS*

After patching it in from upstream it seems to work great

![Two matrix outputs from two separate functions with the same input, 3dgs on top, 4dgs on the bottom. With the first component of the Translation matrix being inverted in the 4dgs output.](https://github.com/user-attachments/assets/163ac70b-e9e0-4d2d-8af1-883f4f6bebe9)

You can see the first component of the Translation matrix is inverted with the current 4dgs handling